### PR TITLE
rc variable unused in ecc.c file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ base_modules = [
         libraries=['gcrypt'],
         include_dirs=['/usr/include', '/usr/local/include',],
         library_dirs=['/usr/local/lib', '/usr/local/lib64',],
-        extra_compile_args=['-Wall', '-Werror',]),
+        extra_compile_args=['-Wall']),
 ]
 
 packages = ['pyecc']


### PR DESCRIPTION
An error was raised while installation of pyECC in ubuntu stating the rc variable in file ecc.c was unused. This warning is preventing it from installation. 

Error

building '_pyecc' extension
gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include -I/usr/local/include -I/usr/include/python2.7 -c seccure/libseccure.c -o build/temp.linux-x86_64-2.7/seccure/libseccure.o -Wall -Werror
gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include -I/usr/local/include -I/usr/include/python2.7 -c seccure/numtheory.c -o build/temp.linux-x86_64-2.7/seccure/numtheory.o -Wall -Werror
gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include -I/usr/local/include -I/usr/include/python2.7 -c seccure/ecc.c -o build/temp.linux-x86_64-2.7/seccure/ecc.o -Wall -Werror
seccure/ecc.c: In function ‘point_decompress’:
seccure/ecc.c:111:12: error: variable ‘rc’ set but not used [-Werror=unused-but-set-variable]
seccure/ecc.c: In function ‘pointmul’:
seccure/ecc.c:364:7: error: variable ‘rc’ set but not used [-Werror=unused-but-set-variable]
cc1: all warnings being treated as errors
" 
